### PR TITLE
#26 Create Car Repository

### DIFF
--- a/libs/domain/src/repositories/car.repository.ts
+++ b/libs/domain/src/repositories/car.repository.ts
@@ -1,0 +1,12 @@
+import type { CarEntity } from '../entities';
+import type { CRUD, SearchParams } from './crud';
+
+export interface CarSearchParams extends SearchParams {
+  brand?: string;
+  type?: CarEntity['type'];
+  status?: CarEntity['status'];
+}
+
+export interface CarRepository extends CRUD<CarEntity, CarSearchParams> {
+  findByUrl(url: string): Promise<CarEntity>;
+}

--- a/libs/domain/src/repositories/index.ts
+++ b/libs/domain/src/repositories/index.ts
@@ -1,3 +1,4 @@
 export * from './crud';
+export * from './car.repository';
 export * from './user.repository';
 export * from './page.repository';


### PR DESCRIPTION
## Summary

- Adds `CarSearchParams extends SearchParams` with entity-specific filters (`brand`, `type`, `status`)
- Adds `CarRepository extends CRUD<CarEntity, CarSearchParams>` with `findByUrl` for slug-based lookup
- Exports from the repositories barrel

> **Note:** Issue #26 is mislabeled "Create User Repository" but the body defines `CarRepository` — implemented accordingly.

## Related issue

Closes #26

## Dependencies

Depends on #37 → #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)