### PR TITLE
feat: extract fastify server into @drivovo/fastify lib with cookie support

### DIFF
--- a/apps/backend/src/endpoints/car.js
+++ b/apps/backend/src/endpoints/car.js
@@ -2,6 +2,6 @@ export const createCarEndpoint = (domain) => [
     {
         path: '/',
         method: 'GET',
-        handler: domain.cars.getAll
+        handler: () => domain.cars.getAll()
     }
 ];

--- a/apps/backend/src/main.js
+++ b/apps/backend/src/main.js
@@ -1,44 +1,19 @@
-import Fastify from 'fastify';
+import { runServer } from '@drivovo/fastify';
 
 import endpointMap from './endpoints/index.js';
 
-// TODO: create nx lib (frameworks) and this function there
-const runServer = async ({ port = 3000, host = '0.0.0.0', endpointMap = {} } = {}) => {
-  const app = Fastify();
-  const endpointEntries = Object.entries(endpointMap);
-
-  for (const [namespace, endpoints] of endpointEntries) {
-    for (const endpoint of endpoints) {
-      app.route({
-        method: endpoint.method,
-        url: `/${namespace}${endpoint.path.startsWith('/') ? '' : '/'}${endpoint.path === '/' ? '' : endpoint.path}`,
-        handler: async (request, reply) => {
-          try {
-            const response = await endpoint.handler(request.params);
-            return reply.send(response);
-          } catch (err) {
-            const errInfo = err.code ? endpoint.errors?.[err.code] : null;
-            if (errInfo) {
-              return reply.status(errInfo.code).send({ code, error: errInfo.message });
-            }
-            return reply.status(500).send({ error: 'Internal Server Error' });
-          }
-        },
-      });
-    }
-  }
-
-  try {
-    await app.listen({ port, host });
-    console.log(`Server is running on port ${port}`);
-  } catch (err) {
-    app.log.error(err);
-    process.exit(1);
-  }
-};
+const port = Number(process.env['PORT'] ?? 3000);
+const host = process.env['HOST'] ?? '0.0.0.0';
 
 runServer({
-  port: Number(process.env['PORT'] ?? 3000),
-  host: process.env['HOST'] ?? '0.0.0.0',
+  port,
+  host,
   endpointMap,
+})
+.then(() => {
+  console.log(`Server listening on ${host}:${port}`);
+})
+.catch((err) => {
+  console.error(err);
+  process.exit(1);
 });

--- a/libs/fastify/package.json
+++ b/libs/fastify/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@drivovo/fastify",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0",
+    "fastify": "^5.7.4",
+    "@fastify/cookie": "^11.0.2"
+  }
+}

--- a/libs/fastify/project.json
+++ b/libs/fastify/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "fastify",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/fastify/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/fastify",
+        "main": "libs/fastify/src/index.ts",
+        "tsConfig": "libs/fastify/tsconfig.lib.json",
+        "assets": ["libs/fastify/*.md"]
+      }
+    }
+  }
+}

--- a/libs/fastify/src/cookies.ts
+++ b/libs/fastify/src/cookies.ts
@@ -1,0 +1,19 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { Cookies } from './types';
+
+export function createCookies(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Cookies {
+  return {
+    get(name) {
+      return request.cookies[name];
+    },
+    set(name, value, options) {
+      reply.setCookie(name, value, options);
+    },
+    delete(name, options) {
+      reply.clearCookie(name, options);
+    },
+  };
+}

--- a/libs/fastify/src/index.ts
+++ b/libs/fastify/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { runServer, type ServerOptions } from './server';

--- a/libs/fastify/src/server.ts
+++ b/libs/fastify/src/server.ts
@@ -1,0 +1,58 @@
+import Fastify from 'fastify';
+import fastifyCookie from '@fastify/cookie';
+import { createCookies } from './cookies';
+import type { Endpoint, EndpointMap, HttpContext } from './types';
+
+export interface ServerOptions {
+  port?: number;
+  host?: string;
+  endpointMap: EndpointMap;
+}
+
+function joinUrl(namespace: string, path: string) {
+  const head = `/${namespace}`;
+  if (path === '/' || path === '') return head;
+  return path.startsWith('/') ? `${head}${path}` : `${head}/${path}`;
+}
+
+export async function runServer({
+  port = 3000,
+  host = '0.0.0.0',
+  endpointMap,
+}: ServerOptions): Promise<void> {
+  const app = Fastify();
+  await app.register(fastifyCookie);
+
+  for (const [namespace, endpoints] of Object.entries(endpointMap)) {
+    for (const endpoint of endpoints as Endpoint[]) {
+      app.route({
+        method: endpoint.method,
+        url: joinUrl(namespace, endpoint.path),
+        handler: async (request, reply) => {
+          try {
+            const ctx: HttpContext = {
+              headers: request.headers,
+              query: request.query,
+              body: request.body,
+              params: request.params,
+              cookies: createCookies(request, reply),
+            };
+            const response = await endpoint.handler(ctx);
+            return reply.send(response);
+          } catch (err: any) {
+            if (err.code && endpoint.errors?.[err.code!]) {
+              const info = endpoint.errors[err.code!];
+              return reply
+                .status(info.code)
+                .send({ code: err.code, error: info.message });
+            }
+            request.log.error(err);
+            return reply.status(500).send({ error: 'Internal Server Error' });
+          }
+        },
+      });
+    }
+  }
+
+  await app.listen({ port, host });
+}

--- a/libs/fastify/src/types.ts
+++ b/libs/fastify/src/types.ts
@@ -1,0 +1,56 @@
+export interface CookieOptions {
+  domain?: string;
+  path?: string;
+  expires?: Date;
+  maxAge?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: 'strict' | 'lax' | 'none';
+}
+
+export interface Cookies {
+  get(name: string): string | undefined;
+  set(name: string, value: string, options?: CookieOptions): void;
+  delete(name: string, options?: Pick<CookieOptions, 'domain' | 'path'>): void;
+}
+
+export type HttpHeaders = Readonly<
+  Record<string, string | string[] | undefined>
+>;
+
+export interface HttpContext<
+  Body = unknown,
+  Query = unknown,
+  Params = unknown,
+> {
+  headers: HttpHeaders;
+  query: Query;
+  body: Body;
+  params: Params;
+  cookies: Cookies;
+}
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface EndpointError {
+  code: number;
+  message: string;
+}
+
+export type EndpointHandler<B, Q, P, R> = (
+  ctx: HttpContext<B, Q, P>,
+) => Promise<R> | R;
+
+export interface Endpoint<
+  B = unknown,
+  Q = unknown,
+  P = unknown,
+  R = unknown,
+> {
+  path: string;
+  method: HttpMethod;
+  handler: EndpointHandler<B, Q, P, R>;
+  errors?: Record<string, EndpointError>;
+}
+
+export type EndpointMap = Record<string, Endpoint[]>;

--- a/libs/fastify/tsconfig.json
+++ b/libs/fastify/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/fastify/tsconfig.lib.json
+++ b/libs/fastify/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "drivovo",
       "version": "0.1.0",
+      "workspaces": [
+        "libs/*"
+      ],
       "dependencies": {
         "@angular/common": "~21.1.0",
         "@angular/compiler": "~21.1.0",
@@ -14,7 +17,6 @@
         "@angular/forms": "~21.1.0",
         "@angular/platform-browser": "~21.1.0",
         "@angular/router": "~21.1.0",
-        "fastify": "^5.7.4",
         "kysely": "^0.28.15",
         "mobx": "^6.15.0",
         "mobx-react-lite": "^4.1.1",
@@ -69,6 +71,22 @@
         "tsx": "^4.21.0",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.55.0"
+      }
+    },
+    "libs/domain": {
+      "version": "0.0.1",
+      "dependencies": {
+        "tslib": "^2.3.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "libs/fastify": {
+      "name": "@drivovo/fastify",
+      "version": "0.0.1",
+      "dependencies": {
+        "@fastify/cookie": "^11.0.2",
+        "fastify": "^5.7.4",
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -6109,6 +6127,10 @@
         "node": ">=14.17.0"
       }
     },
+    "node_modules/@drivovo/fastify": {
+      "resolved": "libs/fastify",
+      "link": true
+    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -6801,6 +6823,26 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@fastify/cookie": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.0.2.tgz",
+      "integrity": "sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.0",
+        "fastify-plugin": "^5.0.0"
+      }
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -9360,6 +9402,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
@@ -19080,13 +19133,16 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie-signature": {
@@ -19932,6 +19988,10 @@
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
+    },
+    "node_modules/domain": {
+      "resolved": "libs/domain",
+      "link": true
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
@@ -21164,6 +21224,16 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -21357,6 +21427,22 @@
         "semver": "^7.6.0",
         "toad-cache": "^3.7.0"
       }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fastify/node_modules/semver": {
       "version": "7.7.4",
@@ -25638,19 +25724,6 @@
         "cookie": "^1.0.1",
         "process-warning": "^4.0.0",
         "set-cookie-parser": "^2.6.0"
-      }
-    },
-    "node_modules/light-my-request/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/light-my-request/node_modules/process-warning": {
@@ -35887,7 +35960,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "migrate:status": "tsx apps/backend/scripts/migrate.ts status",
     "migrate:create": "tsx apps/backend/scripts/migrate.ts create"
   },
+  "workspaces": [
+    "libs/*"
+  ],
   "dependencies": {
     "@angular/common": "~21.1.0",
     "@angular/compiler": "~21.1.0",
@@ -28,7 +31,6 @@
     "@angular/forms": "~21.1.0",
     "@angular/platform-browser": "~21.1.0",
     "@angular/router": "~21.1.0",
-    "fastify": "^5.7.4",
     "kysely": "^0.28.15",
     "mobx": "^6.15.0",
     "mobx-react-lite": "^4.1.1",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,8 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@drivovo/domain": ["libs/domain/src/index.ts"]
+      "@drivovo/domain": ["libs/domain/src/index.ts"],
+      "@drivovo/fastify": ["libs/fastify/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary
- Extract Fastify runtime from `apps/backend/src/main.js` into new `@drivovo/fastify` lib (`libs/fastify`) with `runServer`, typed `HttpContext`, `Endpoint`, and `EndpointMap`
- Add `@fastify/cookie` integration exposed as a framework-agnostic `Cookies` interface (`get` / `set` / `delete`) on the endpoint context — foundation for upcoming JWT work
- Wire `libs/*` npm workspaces and add `@drivovo/fastify` path mapping in `tsconfig.base.json`; fix car endpoint handler invocation

## Test plan
- [ ] `npm install` resolves the new workspace without drift
- [ ] `nx build fastify` succeeds
- [ ] Backend boots and `GET /car/` returns cars via the new `runServer`
- [ ] Setting/reading cookies through `ctx.cookies` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)