### PR TITLE
OB-3: fix: make images field optional in CarsTable schema

### DIFF
--- a/apps/backend/src/infrastructure/database/tables/car.ts
+++ b/apps/backend/src/infrastructure/database/tables/car.ts
@@ -24,7 +24,7 @@ export interface CarsTable {
   engine_type: FuelType;
   engine_capacity: string | null;
   engine_fuel_cons: string | null;
-  images: JSONColumnType<ImageJson[]>;
+  images?: JSONColumnType<ImageJson[]>;
 }
 
 export function createCarEntity(row: Selectable<CarsTable>, price?: Price): CarEntity {
@@ -68,7 +68,6 @@ export function createCarTable(entity: CarEntity): Insertable<CarsTable> {
     engine_type: entity.engine.type,
     engine_capacity: entity.engine.capacity || null,
     engine_fuel_cons: entity.engine.fuel_consumption || null,
-    images: JSON.stringify(entity.images.map(createImageJson)),
   };
 }
 


### PR DESCRIPTION
## Problem
The `CarsTable` Kysely schema interface defined `images` as a required field, but the actual PostgreSQL database table doesn't have an `images` column. When attempting to insert a car, Kysely would include this non-existent field in the INSERT statement, causing PostgreSQL to throw:
```
column "images" of relation "cars" does not exist
```

This manifested as an "Internal Server Error" (500) for any POST request to create a car.

## Solution
Made the `images` field optional in the `CarsTable` interface:
```typescript
images?: JSONColumnType<ImageJson[]>;  // Optional - may not exist in older schema
```

Updated `createCarTable()` to exclude the images field from INSERT statements since the database column doesn't exist. When reading cars, the missing column returns as `undefined`, which is safely coerced to an empty array `[]` by the existing nullish coalescing operator in `createCarEntity()`.

## Testing
- Verified that POST requests now complete without errors
- Confirmed that existing cars still render with empty `images` arrays
- Validated that all other car fields insert and read correctly

This fix must be merged before the create endpoint feature to prevent 500 errors.