### PR TITLE
#29 backend: add UserRepository

### DIFF
--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -2,12 +2,14 @@ import adminRepository, { type AdminRepository } from './admin.repository';
 import carRepository, { type CarRepository } from './car.repository';
 import pageRepository, { type PageRepository } from './page.repository';
 import sessionRepository, { type SessionRepository } from './session.repository';
+import userRepository, { type UserRepository } from './user.repository';
 
 export interface Repositories {
   admins: AdminRepository;
   cars: CarRepository;
   pages: PageRepository;
   sessions: SessionRepository;
+  users: UserRepository;
 }
 
 export default {
@@ -15,4 +17,5 @@ export default {
   cars: carRepository,
   pages: pageRepository,
   sessions: sessionRepository,
+  users: userRepository,
 } satisfies Repositories;

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -1,0 +1,125 @@
+import type { UserEntity } from '@drivovo/domain';
+import db from '../infrastructure/database';
+import {
+  createUserEntity,
+  createUserTable,
+  createUserUpdates,
+} from '../infrastructure/database/tables';
+import { type Repository, type SearchParams, RepositoryError } from './repository';
+
+const SORT_FIELD_MAP = {
+  name: 'name',
+  email: 'email',
+  phone: 'phone',
+  driving_experience: 'driving_experience',
+  came_from: 'came_from',
+  created_at: 'created_at',
+  updated_at: 'updated_at',
+} as const;
+
+type UserSearchParams = SearchParams<keyof typeof SORT_FIELD_MAP>;
+
+export interface UserRepository extends Repository<UserEntity, UserSearchParams> {
+  findByEmail(email: string): Promise<UserEntity | null>;
+  findByPhone(phone: string): Promise<UserEntity | null>;
+}
+
+export default {
+  async find(params: UserSearchParams = {}): Promise<UserEntity[]> {
+    try {
+      const rows = await db
+        .selectFrom('users')
+        .selectAll()
+        .$if(Boolean(params?.sortField && SORT_FIELD_MAP[params.sortField!]), (query) =>
+          query.orderBy(SORT_FIELD_MAP[params.sortField!], params.sortOrder),
+        )
+        .$if(Boolean(params?.limit), (query) => query.limit(params.limit!))
+        .$if(Boolean(params?.offset), (query) => query.offset(params.offset!))
+        .execute();
+      return rows.map((row) => createUserEntity(row));
+    } catch (error) {
+      throw RepositoryError.from(error);
+    }
+  },
+
+  async findOne(id: string): Promise<UserEntity | null> {
+    try {
+      const row = await db
+        .selectFrom('users')
+        .selectAll()
+        .where('id', '=', id)
+        .executeTakeFirst();
+      return row ? createUserEntity(row) : null;
+    } catch (error) {
+      throw RepositoryError.from(error);
+    }
+  },
+
+  async findByEmail(email: string): Promise<UserEntity | null> {
+    try {
+      const row = await db
+        .selectFrom('users')
+        .selectAll()
+        .where('email', '=', email)
+        .executeTakeFirst();
+      return row ? createUserEntity(row) : null;
+    } catch (error) {
+      throw RepositoryError.from(error);
+    }
+  },
+
+  async findByPhone(phone: string): Promise<UserEntity | null> {
+    try {
+      const row = await db
+        .selectFrom('users')
+        .selectAll()
+        .where('phone', '=', phone)
+        .executeTakeFirst();
+      return row ? createUserEntity(row) : null;
+    } catch (error) {
+      throw RepositoryError.from(error);
+    }
+  },
+
+  async insert(entity: UserEntity): Promise<string | null> {
+    try {
+      const result = await db
+        .insertInto('users')
+        .values(createUserTable(entity))
+        .returning('id')
+        .executeTakeFirst();
+      return result?.id ?? null;
+    } catch (error) {
+      throw RepositoryError.from(error);
+    }
+  },
+
+  async update(entity: Partial<UserEntity> & { id: string }): Promise<string | null> {
+    try {
+      const updates = createUserUpdates(entity);
+      if (Object.keys(updates).length === 0) return entity.id;
+      const result = await db
+        .updateTable('users')
+        .set(updates)
+        .where('id', '=', entity.id)
+        .returning('id')
+        .executeTakeFirst();
+      return result?.id ?? null;
+    } catch (error) {
+      throw RepositoryError.from(error);
+    }
+  },
+
+  async delete(id: string): Promise<string | null> {
+    try {
+      const result = await db
+        .deleteFrom('users')
+        .where('id', '=', id)
+        .returning('id')
+        .executeTakeFirst();
+      return result?.id ?? null;
+    } catch (error) {
+      throw RepositoryError.from(error);
+    }
+  },
+} satisfies UserRepository;


### PR DESCRIPTION
Closes #29 (supersedes #36 — closed as outdated against current patterns).

## Summary

- `apps/backend/src/repositories/user.repository.ts` — new repository following the established pattern (closest template: `admin.repository.ts`, since it already has `findByEmail`).
- Wired into `apps/backend/src/repositories/index.ts` as `users`.

## Pattern compliance

Matches the conventions used by `admin.repository.ts` / `car.repository.ts`:
- Implements `Repository<UserEntity, UserSearchParams>` from `./repository`.
- `UserSearchParams = SearchParams<keyof typeof SORT_FIELD_MAP>` — sort-field whitelist.
- Every method wraps DB calls in `try/catch` → `throw RepositoryError.from(error)`.
- `insert/update/delete` return `Promise<string | null>` (id).
- `update` short-circuits to `entity.id` when there are no fields to update.
- Uses `createUserEntity` / `createUserTable` / `createUserUpdates` mappers (already on main).
- Default-exported object literal `satisfies UserRepository`.

## Extras (beyond `admin`)

- `findByPhone(phone)` in addition to `findByEmail(email)` — per #29 requirements.

## Test plan

- [ ] `nx build backend` passes in CI (local env has a broken `node_modules` due to an unrelated `@fastify/cookie` install failure; the only TS errors observed locally are in `libs/fastify/src/server.ts` and predate this change)
- [ ] Integration smoke (real Postgres): insert → findByEmail → findByPhone → update → delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)