### PR TITLE
#29 backend: add UserService (zod validation + uniqueness)

### DIFF
--- a/apps/backend/src/domain/services/index.js
+++ b/apps/backend/src/domain/services/index.js
@@ -2,6 +2,7 @@ import repositories from '../../repositories';
 import { createCarService } from './car';
 import createAdminService from './admin';
 import createSessionService from './session';
+import createUserService from './user';
 
 const deps = { repositories };
 
@@ -9,4 +10,5 @@ export default {
   cars: createCarService(deps),
   admins: createAdminService(deps),
   sessions: createSessionService(deps),
+  users: createUserService(deps),
 };

--- a/apps/backend/src/domain/services/user.ts
+++ b/apps/backend/src/domain/services/user.ts
@@ -1,0 +1,115 @@
+import { type UserEntity, userSchema } from '@drivovo/domain';
+import { z } from 'zod';
+import type { UserSearchParams } from '../../repositories/user.repository';
+import { type Dependencies, DOMAIN_ERRORS, DomainError } from './service';
+
+export type CreateUserInput = Omit<UserEntity, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateUserInput = Partial<Omit<UserEntity, 'createdAt' | 'updatedAt'>> & { id: string };
+
+export const USER_ERRORS = {
+  EMAIL_TAKEN: 'EMAIL_TAKEN',
+  PHONE_TAKEN: 'PHONE_TAKEN',
+} as const;
+
+export interface UserService {
+  getAll(params?: UserSearchParams): Promise<UserEntity[]>;
+  getById(id: string): Promise<UserEntity>;
+  getByEmail(email: string): Promise<UserEntity | null>;
+  getByPhone(phone: string): Promise<UserEntity | null>;
+  create(input: CreateUserInput): Promise<string>;
+  update(input: UpdateUserInput): Promise<string>;
+  delete(id: string): Promise<string>;
+}
+
+function formatIssues(error: z.ZodError): string {
+  return error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+}
+
+function validateId(id: string): void {
+  const result = userSchema.shape.id.safeParse(id);
+  if (!result.success) {
+    throw new DomainError(DOMAIN_ERRORS.VALIDATION_ERROR, `Invalid id: ${id}`);
+  }
+}
+
+function validateCreate(input: CreateUserInput): void {
+  const schema = userSchema.omit({ id: true, createdAt: true, updatedAt: true });
+  const result = schema.safeParse(input);
+  if (!result.success) {
+    throw new DomainError(DOMAIN_ERRORS.VALIDATION_ERROR, formatIssues(result.error));
+  }
+}
+
+function validateUpdate(input: UpdateUserInput): void {
+  const schema = userSchema
+    .partial()
+    .omit({ createdAt: true, updatedAt: true })
+    .extend({ id: userSchema.shape.id });
+  const result = schema.safeParse(input);
+  if (!result.success) {
+    throw new DomainError(DOMAIN_ERRORS.VALIDATION_ERROR, formatIssues(result.error));
+  }
+}
+
+export default ({ repositories: repos }: Dependencies): UserService => {
+  async function ensureEmailFree(email: string, excludeId?: string): Promise<void> {
+    const existing = await repos.users.findByEmail(email);
+    if (existing && existing.id !== excludeId) {
+      throw new DomainError(USER_ERRORS.EMAIL_TAKEN, `User with email ${email} already exists`);
+    }
+  }
+
+  async function ensurePhoneFree(phone: string, excludeId?: string): Promise<void> {
+    const existing = await repos.users.findByPhone(phone);
+    if (existing && existing.id !== excludeId) {
+      throw new DomainError(USER_ERRORS.PHONE_TAKEN, `User with phone ${phone} already exists`);
+    }
+  }
+
+  return {
+    getAll: (params?: UserSearchParams) => repos.users.find(params),
+
+    async getById(id) {
+      validateId(id);
+      const user = await repos.users.findOne(id);
+      if (!user) {
+        throw new DomainError(DOMAIN_ERRORS.NOT_FOUND, `User with id ${id} not found`);
+      }
+      return user;
+    },
+
+    getByEmail: (email) => repos.users.findByEmail(email),
+    getByPhone: (phone) => repos.users.findByPhone(phone),
+
+    async create(input) {
+      validateCreate(input);
+      await ensureEmailFree(input.email);
+      await ensurePhoneFree(input.phone);
+      const id = await repos.users.insert(input as UserEntity);
+      if (!id) {
+        throw new DomainError(DOMAIN_ERRORS.UNKNOWN_ERROR, 'Failed to create user');
+      }
+      return id;
+    },
+
+    async update(input) {
+      validateUpdate(input);
+      if (input.email !== undefined) await ensureEmailFree(input.email, input.id);
+      if (input.phone !== undefined) await ensurePhoneFree(input.phone, input.id);
+      const id = await repos.users.update(input);
+      if (!id) {
+        throw new DomainError(DOMAIN_ERRORS.NOT_FOUND, `User with id ${input.id} not found`);
+      }
+      return id;
+    },
+
+    async delete(id) {
+      validateId(id);
+      const deletedId = await repos.users.delete(id);
+      if (!deletedId) {
+        throw new DomainError(DOMAIN_ERRORS.NOT_FOUND, `User with id ${id} not found`);
+      }
+      return deletedId;
+    },
+  };
+};

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -17,7 +17,7 @@ const SORT_FIELD_MAP = {
   updated_at: 'updated_at',
 } as const;
 
-type UserSearchParams = SearchParams<keyof typeof SORT_FIELD_MAP>;
+export type UserSearchParams = SearchParams<keyof typeof SORT_FIELD_MAP>;
 
 export interface UserRepository extends Repository<UserEntity, UserSearchParams> {
   findByEmail(email: string): Promise<UserEntity | null>;

--- a/libs/domain/src/entities/user.ts
+++ b/libs/domain/src/entities/user.ts
@@ -1,4 +1,27 @@
-type Experience = 'beginner' | 'intermediate' | 'advanced';
+import { z } from 'zod';
+
+const experienceSchema = z.enum(['beginner', 'intermediate', 'advanced']);
+const availabilityDaySchema = z.enum(['today', 'tomorrow', 'weekend']);
+const availabilityTimeSchema = z.enum(['morning', 'afternoon', 'evening']);
+const drinksSchema = z.enum(['coffee', 'tea']);
+
+export type Experience = z.infer<typeof experienceSchema>;
+
+export const userSchema = z.object({
+    id: z.string().uuid(),
+    name: z.string().min(1),
+    email: z.string().email(),
+    phone: z.string().min(1),
+    drivingExperience: experienceSchema,
+    cameFrom: z.string(),
+    availability: z.object({
+        day: availabilityDaySchema,
+        time: availabilityTimeSchema,
+    }),
+    drinks: drinksSchema.optional(),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+});
 
 export interface UserEntity {
     id: string;
@@ -8,10 +31,10 @@ export interface UserEntity {
     drivingExperience: Experience;
     cameFrom: string;
     availability: {
-        day: 'today' | 'tomorrow' | 'weekend';
-        time: 'morning' | 'afternoon' | 'evening';
+        day: z.infer<typeof availabilityDaySchema>;
+        time: z.infer<typeof availabilityTimeSchema>;
     };
-    drinks?: 'coffee' | 'tea';
+    drinks?: z.infer<typeof drinksSchema>;
     createdAt: Date;
     updatedAt: Date;
 }


### PR DESCRIPTION
Builds on #55 (UserRepository). Adds the domain-service layer for users.

## Summary

- `libs/domain/src/entities/user.ts` — adds `userSchema` (zod) mirroring `adminSchema`; `Experience` is now derived from the schema so the type and schema stay in sync.
- `apps/backend/src/domain/services/user.ts` — new `UserService` following the `page.ts` (zod validation) + `admin.ts` (error translation) patterns.
- `apps/backend/src/repositories/user.repository.ts` — exports `UserSearchParams` (was internal).
- `apps/backend/src/domain/services/index.js` — registers `users`.

## Design decisions

Defaults from `docs/users-service-plan.md` §8 (all confirmed before coding):
- **Phone validation:** permissive `z.string().min(1)` — no E.164 enforcement yet.
- **Delete:** hard delete (matches admins / cars).
- **Uniqueness — Option A (pre-check):** before `insert`/`update`, the service runs `findByEmail` and `findByPhone`. If an existing user is found with a different id, throws `EMAIL_TAKEN` / `PHONE_TAKEN`. Trade-off: two extra DB round-trips per write and a TOCTOU race window, but precise per-column errors without leaking constraint names into the service. Race-loser would still surface as a generic `DUPLICATE_ERROR` — acceptable for now.
- **`UserSearchParams` location:** exported from the repository module (one source of truth for sort-field whitelist).
- **No `changeEmail` / `changePhone`** business ops yet — deferred until a real flow needs them.

## Error matrix

| Operation | Possible `DomainError.code` |
|---|---|
| `getById` | `VALIDATION_ERROR` (bad uuid), `NOT_FOUND` |
| `create` | `VALIDATION_ERROR`, `EMAIL_TAKEN`, `PHONE_TAKEN`, `UNKNOWN_ERROR` |
| `update` | `VALIDATION_ERROR`, `EMAIL_TAKEN`, `PHONE_TAKEN`, `NOT_FOUND` |
| `delete` | `VALIDATION_ERROR`, `NOT_FOUND` |

## Test plan

- [x] `nx build backend` passes locally
- [ ] Integration smoke against real Postgres: create → duplicate email → `EMAIL_TAKEN`; duplicate phone → `PHONE_TAKEN`; update self-email → succeeds; getById unknown → `NOT_FOUND`
- [ ] Unit-level Jest spec with mocked `repositories.users` locking the error matrix (deferred; can land in a follow-up)

## Next on the users vertical

REST endpoints (`apps/backend/src/endpoints/user.js`), then auth-related fields (`passwordHash` / `passwordSalt` mirroring admin auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)